### PR TITLE
 Make server API URL generator IPv6 friendly

### DIFF
--- a/script/install-cni.sh
+++ b/script/install-cni.sh
@@ -56,7 +56,7 @@ kind: Config
 clusters:
 - name: local
   cluster:
-    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}
+    server: ${KUBERNETES_SERVICE_PROTOCOL:-https}://[${KUBERNETES_SERVICE_HOST}]:${KUBERNETES_SERVICE_PORT}
     $TLS_CFG
 users:
 - name: whereabouts


### PR DESCRIPTION
Inspired from: https://github.com/projectcalico/cni-plugin/blob/be4df4db2e47aa7378b1bdf6933724bac1f348d0/k8s-install/scripts/install-cni.sh#L104-L153

This change fixes an issue where the KUBERNETES_SERVICE_HOST is an IPv6 IP. The resulting kubeconfig is generated as such:
```
- name: local
  cluster:
    server: https://fd00:102::1:443
```

IPv6 addresses require square braces around them to differentiate the IP from the port. Thankfully, square braces work for IPv4 addresses as well. 